### PR TITLE
Font lock fixes

### DIFF
--- a/todotxt-mode.el
+++ b/todotxt-mode.el
@@ -89,6 +89,7 @@
 
 (defconst todotxt-nord-colours
   '(
+    ("nord0" . "#2e3440")
     ("nord7" . "#5e81ac")
     ("nord11" . "#bf616a")
     ("nord12" . "#d08770")
@@ -113,9 +114,8 @@
 (defface todotxt-a-priority-face
   (list
    (list 't
-         :underline (list
-                     :color (todotxt-nord "nord11")
-                     :style 'wave)
+         :background (todotxt-nord "nord11")
+         :foreground (todotxt-nord "nord0")
          )
    )
   "Face for tasks with A priority"
@@ -124,10 +124,8 @@
 (defface todotxt-b-priority-face
   (list
    (list 't
-         :underline (list
-                     :color (todotxt-nord "nord12")
-                     :style 'wave
-                     )
+         :background (todotxt-nord "nord12")
+         :foreground (todotxt-nord "nord0")
          )
    )
   "Face for B priority tasks"
@@ -136,10 +134,8 @@
 (defface todotxt-c-priority-face
   (list
    (list 't
-         :underline (list
-                     :color (todotxt-nord "nord13")
-                     :style 'wave
-                     )
+         :background (todotxt-nord "nord13")
+         :foreground (todotxt-nord "nord0")
          )
    )
   "Face for C priority tasks"
@@ -161,20 +157,20 @@
 (setq todotxt-mode-keywords
   '(
 	("^x .*$" 0 'todotxt-done-face)
-	("^(A).*$" 0 'todotxt-a-priority-face)
-	("^(B).*$" 0 'todotxt-b-priority-face)
-	("^(C).*$" 0 'todotxt-c-priority-face)
+	("^(A)" 0 'todotxt-a-priority-face)
+	("^(B)" 0 'todotxt-b-priority-face)
+	("^(C)" 0 'todotxt-c-priority-face)
 	;("^.*#waiting.*" 0 '(:foreground "DeepPink1")) ; special tag
 	;("^.*#important.*" 0 '(:foreground "IndianRed")) ; special tag
 	("([A-Z]+)" . font-lock-builtin-face)
 	("\\([a-zA-Z0-9_-]+\\):\\([a-zA-Z0-9._-]+\\)" . font-lock-variable-name-face)
-	("+[[:alnum:]_]+" . font-lock-function-name-face)
-	("@[[:alnum:]_]+" . font-lock-type-face)
+	("+[[:alnum:]_]+" 0 font-lock-function-name-face)
+	("@[[:alnum:]_]+" 0 font-lock-type-face)
 	("#important" 0 '(:foreground "orange red")) ; special tag
 	("#waiting" 0 '(:foreground "dark orange")) ; special tag
 	("#\\w+" . font-lock-comment-face)
 	("-\\([a-zA-Z_-]+\\)" . font-lock-variable-name-face)
-	("^[0-9]+-[0-9]+-[0-9]+" 0 'todotxt-date-face)))
+	("[0-9]+-[0-9]+-[0-9]+" 0 'todotxt-date-face)))
 
 ;;;
 ;;; Todotxt Functions for managing the file

--- a/todotxt-mode.el
+++ b/todotxt-mode.el
@@ -81,6 +81,78 @@
   (define-key todotxt-mode-map "x" 'todotxt-insert-x-maybe-complete)
 )
 
+;;
+;; Faces
+;;
+
+;; Colours are taken from the Nord theme: https://www.nordtheme.com/docs/colors-and-palettes                                
+
+(defconst todotxt-nord-colours
+  '(
+    ("nord7" . "#5e81ac")
+    ("nord11" . "#bf616a")
+    ("nord12" . "#d08770")
+    ("nord13" . "#ebcb8b")
+    )
+  "Nord to RGB maps."
+  )
+
+(defun todotxt-nord (colour)
+  (cdr (assoc colour todotxt-nord-colours)))
+
+(defface todotxt-done-face
+  (list
+   (list 't
+         :foreground (todotxt-nord "nord7")
+         :strike-through 't
+         )
+   )
+  "Face for accomplished tasks."
+  )
+
+(defface todotxt-a-priority-face
+  (list
+   (list 't
+         :underline (list
+                     :color (todotxt-nord "nord11")
+                     :style 'wave)
+         )
+   )
+  "Face for tasks with A priority"
+  )
+
+(defface todotxt-b-priority-face
+  (list
+   (list 't
+         :underline (list
+                     :color (todotxt-nord "nord12")
+                     :style 'wave
+                     )
+         )
+   )
+  "Face for B priority tasks"
+  )
+
+(defface todotxt-c-priority-face
+  (list
+   (list 't
+         :underline (list
+                     :color (todotxt-nord "nord13")
+                     :style 'wave
+                     )
+         )
+   )
+  "Face for C priority tasks"
+  )
+
+(defface todotxt-date-face
+  (list (list 't
+              :foreground (todotxt-nord "nord7")
+              )
+        )
+  "Face for date strings"
+  )
+
 ;;;
 ;;; Font-lock keywords
 ;;;
@@ -88,10 +160,10 @@
 (defvar todotxt-mode-keywords nil "Font lock keywords for todotxt-mode")
 (setq todotxt-mode-keywords
   '(
-	("^x .*$" 0 '(:foreground "gray80" :strike-through t))
-	("^(A).*$" 0 '(:background "red"))
-	("^(B).*$" 0 '(:background "orange"))
-	("^(C).*$" 0 '(:background "orange"))
+	("^x .*$" 0 'todotxt-done-face)
+	("^(A).*$" 0 'todotxt-a-priority-face)
+	("^(B).*$" 0 'todotxt-b-priority-face)
+	("^(C).*$" 0 'todotxt-c-priority-face)
 	;("^.*#waiting.*" 0 '(:foreground "DeepPink1")) ; special tag
 	;("^.*#important.*" 0 '(:foreground "IndianRed")) ; special tag
 	("([A-Z]+)" . font-lock-builtin-face)
@@ -102,7 +174,7 @@
 	("#waiting" 0 '(:foreground "dark orange")) ; special tag
 	("#\\w+" . font-lock-comment-face)
 	("-\\([a-zA-Z_-]+\\)" . font-lock-variable-name-face)
-	("^[0-9]+-[0-9]+-[0-9]+" 0 '(:foreground "gray90"))))
+	("^[0-9]+-[0-9]+-[0-9]+" 0 'todotxt-date-face)))
 
 ;;;
 ;;; Todotxt Functions for managing the file

--- a/todotxt-mode.el
+++ b/todotxt-mode.el
@@ -168,8 +168,8 @@
 	;("^.*#important.*" 0 '(:foreground "IndianRed")) ; special tag
 	("([A-Z]+)" . font-lock-builtin-face)
 	("\\([a-zA-Z0-9_-]+\\):\\([a-zA-Z0-9._-]+\\)" . font-lock-variable-name-face)
-	("+\\w+" . font-lock-function-name-face)
-	("@\\w+" . font-lock-type-face)
+	("+[[:alnum:]_]+" . font-lock-function-name-face)
+	("@[[:alnum:]_]+" . font-lock-type-face)
 	("#important" 0 '(:foreground "orange red")) ; special tag
 	("#waiting" 0 '(:foreground "dark orange")) ; special tag
 	("#\\w+" . font-lock-comment-face)


### PR DESCRIPTION
Some fixes for font-lock faces. I created some faces so you can customize them. I use the [Nord theme's colours](https://www.nordtheme.com/docs/colors-and-palettes) in order to make them "eye-comfortable".

Also, I found that a red/orange background for priority tasks misses the other faces applied. I allow them to be applied to the priority characters only and not the entire line (`(A)`, `(B)` or `(C)` characters only). I tried to underline all the line, but didn't like it.

Here's a screenshot:
![Screenshot_20191015_150406](https://user-images.githubusercontent.com/1332276/66857220-2f88c400-ef5d-11e9-8458-8913b2e519c3.png)
